### PR TITLE
Enrich comments: threading, reactions, edit history, events, mentions (v0.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this package will be documented in this file.
 
+## v0.1.0 (01-Jul-2026)
+- Renamed the `text` column to `body`.
+- Added backward-compatible `text` and `comment` model aliases that read from / write to `body`, so existing code using `$comment->text`, `$comment->comment`, or `createComment(['text' => ...])` keeps working.
+- **Threading**: comments can reply to other comments via `reply_to_comment_id`; adds `replyToComment()` / `replies()` relations and `HasComments::rootComments()` (top-level only).
+- **Reactions**: `comment_reactions` table + `CommentReaction` model, one reaction per user per comment, via `$comment->react($user, $reaction)` / `unreact($user)` and `$comment->reactions()`.
+- **Edit history (opt-in)**: when `config('comments.changelog')` is true, each body edit snapshots into `comment_changelogs` (`CommentChangelog` model, `$comment->changelogs()`).
+- **Lifecycle events**: `CommentCreated`, `CommentUpdated` (carries `previousBody`), `CommentDeleted`, `ReactionAdded`, `ReactionRemoved` — apps hook these for notifications / broadcasts / activity; the package stays framework-agnostic.
+- **Mentions**: `$comment->mentionedHandles()` parses `@handles` from the body (config-driven pattern). Resolving handles and delivering notifications is left to the app.
+- **Config** (`config/comments.php`): `user_model`, overridable `models`, `changelog`, `mentions.pattern`, and `auto_load_migrations` (set false in apps that own the `comments` schema, e.g. otper).
+- All additions are additive/backward-compatible; no existing column, relation, or API was removed or renamed.
+
 ## v0.0.2 (21-Jan-2025)
 - some database changes
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,15 @@ php artisan vendor:publish --tag="laravel-comments-migrations"
 php artisan migrate
 ```
 
+Publish the config to customise behaviour (user model, edit history, mention pattern, etc.):
+
+```bash
+php artisan vendor:publish --tag="laravel-comments-config"
+```
+
+> Apps that already own a `comments` table (and manage the schema themselves) can set
+> `comments.auto_load_migrations` to `false` so the package does not register its own migrations.
+
 ## Usage
 
 Add the `HasComments` trait to your model.
@@ -47,8 +56,9 @@ $comment = $model->createComment([
     // type: Optional. It represents the type of comment.
     'type' => 'commentType', 
 
-    // text: This is text of the comment.
-    'text' => 'The is the text of the comment', 
+    // body: This is the body of the comment.
+    // (The `text` and `comment` keys are still accepted as backward-compatible aliases.)
+    'body' => 'This is the body of the comment', 
 
     // user_id: Optional. This is a foreign key belonging to that entity who is making the comment. For e.g:Users(so it will be the id of User who is making the comment).
     'user_id' => 1,
@@ -85,7 +95,13 @@ $comment->file //To access the first or only attachment with that comment on the
 $comment->files //To access all the attachments related to that comment on that card
 
 //One can update particular comment by adding id as one of the params
-$card->createComment(['id' => 23, 'user_id' => 2,'text'=> "This is a new comment"])
+$card->createComment(['id' => 23, 'user_id' => 2,'body'=> "This is a new comment"])
+
+// The comment body is stored in the `body` column. For backward compatibility,
+// `$comment->text` and `$comment->comment` both read from / write to `body`.
+$comment->body;    // "This is a new comment"
+$comment->text;    // same value (alias)
+$comment->comment; // same value (alias)
 
 //Like this one can delete all the comments along with its attachment on the card
 $comments = $card->comments()->get();
@@ -95,6 +111,77 @@ foreach($comments as $comment) {
 
 ```
 
+
+### Threading (replies)
+
+A comment can reply to another via `reply_to_comment_id`:
+
+```php
+$reply = $card->createComment([
+    'user_id' => 2,
+    'body' => 'I agree',
+    'reply_to_comment_id' => $comment->id,
+]);
+
+$reply->replyToComment; // the parent comment
+$comment->replies;      // replies to this comment
+$card->rootComments();  // top-level comments only (excludes replies)
+```
+
+### Reactions
+
+One reaction per user per comment (re-reacting changes it):
+
+```php
+$comment->react($user, 'thumbsup'); // add or change $user's reaction
+$comment->unreact($user);           // remove it
+$comment->reactions;                // all reactions on the comment
+```
+
+### Edit history (opt-in)
+
+Set `comments.changelog` to `true` to snapshot each edit. On every change to `body`,
+the *previous* body is stored in `comment_changelogs`, so the changelog table holds all
+prior versions and the model holds the current one — the full history is reconstructable.
+
+```php
+$comment->changelogs; // prior versions, newest first
+```
+
+### Mentions
+
+The package parses `@handles` out of the body; resolving them to users and delivering
+notifications is your app's job (typically in a listener on the events below).
+
+```php
+$comment->mentionedHandles(); // ['bob', 'carol.dev']
+```
+
+The pattern is configurable via `comments.mentions.pattern`.
+
+### Events
+
+The package fires framework-agnostic events so your app can send notifications, broadcast,
+or record activity without the package knowing about any of that:
+
+| Event | When |
+|---|---|
+| `CommentCreated` | a comment is created |
+| `CommentUpdated` | a comment's body is edited (carries `previousBody`) |
+| `CommentDeleted` | a comment is deleted |
+| `ReactionAdded` | a user reacts (or changes their reaction) |
+| `ReactionRemoved` | a user removes their reaction |
+
+```php
+Event::listen(\Ssntpl\LaravelComments\Events\CommentCreated::class, function ($event) {
+    // $event->comment->mentionedHandles(), notify, broadcast, ...
+});
+```
+
+### Overriding models
+
+Point `comments.models.*` at your own subclasses to add behaviour. Custom classes **must
+extend** the package base (`Comment` / `CommentReaction` / `CommentChangelog`).
 
 ## Changelog
 

--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,16 @@
 {
     "name": "ssntpl/laravel-comments",
-    "description": "Creating comments with information like text, date and type of comment along with user",
+    "description": "Polymorphic comments for Eloquent models: threading, reactions, per-comment files, opt-in edit history, mentions, and lifecycle events.",
     "type": "library",
     "license": "MIT",
     "autoload": {
         "psr-4": {
             "Ssntpl\\LaravelComments\\": "src"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Ssntpl\\LaravelComments\\Tests\\": "tests"
         }
     },
     "authors": [
@@ -23,10 +28,11 @@
     },
     "minimum-stability": "dev",
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.1",
         "ssntpl/laravel-files": "^0.1.6"
     },
     "require-dev": {
-        "laravel/framework": "^9.0|^10.0|^11.0"
+        "laravel/framework": "^10.0|^11.0",
+        "orchestra/testbench": "^8.0|^9.0"
     }
 }

--- a/config/comments.php
+++ b/config/comments.php
@@ -1,0 +1,57 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | User model
+    |--------------------------------------------------------------------------
+    | The model a comment's `user_id` belongs to. Defaults to the app's
+    | configured auth user model.
+    */
+    'user_model' => env('COMMENTS_USER_MODEL') ?: (config('auth.providers.users.model') ?? 'App\\Models\\User'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Models
+    |--------------------------------------------------------------------------
+    | Point these at your own subclasses if you need extra behaviour. The
+    | package resolves related models through these keys.
+    */
+    'models' => [
+        'comment'   => \Ssntpl\LaravelComments\Models\Comment::class,
+        'reaction'  => \Ssntpl\LaravelComments\Models\CommentReaction::class,
+        'changelog' => \Ssntpl\LaravelComments\Models\CommentChangelog::class,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Edit history (changelog)
+    |--------------------------------------------------------------------------
+    | When true, every edit to a comment's body snapshots the new body into the
+    | `comment_changelogs` table. Off by default — enable per app that wants it.
+    */
+    'changelog' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Mentions
+    |--------------------------------------------------------------------------
+    | The package only PARSES mentions out of the body (returns the raw handles);
+    | resolving handles to users and delivering notifications is the app's job,
+    | typically via the CommentCreated / CommentUpdated events.
+    */
+    'mentions' => [
+        'pattern' => '/@([A-Za-z0-9_.\-]+)/',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Auto-load migrations
+    |--------------------------------------------------------------------------
+    | When true, the package registers its own migrations. Set false in apps
+    | that already own a `comments` table and manage the schema themselves
+    | (e.g. otper) so the package migrations don't collide.
+    */
+    'auto_load_migrations' => true,
+];

--- a/database/migrations/2025_01_06_124005_create_comments_table.php
+++ b/database/migrations/2025_01_06_124005_create_comments_table.php
@@ -15,11 +15,16 @@ return new class extends Migration
             $table->id();
             $table->unsignedBigInteger('owner_id');
             $table->string('owner_type');
-            $table->foreignId('user_id')->nullable()->constrained()->onDelete('set null')->onUpdate('cascade');
+            // No DB-level FK: the user model/table is app-configurable (config('comments.user_model')).
+            $table->unsignedBigInteger('user_id')->nullable()->index();
             $table->string('type')->nullable();
-            $table->text('text');
+            $table->text('body');
+            // Threading: a comment may be a reply to another comment.
+            $table->unsignedBigInteger('reply_to_comment_id')->nullable();
             $table->timestamps();
             $table->index(['owner_id', 'owner_type'], 'comments_owner_id_owner_type_index');
+            $table->index('reply_to_comment_id');
+            $table->foreign('reply_to_comment_id')->references('id')->on('comments')->nullOnDelete();
         });
     }
 

--- a/database/migrations/2025_01_06_124010_create_comment_reactions_table.php
+++ b/database/migrations/2025_01_06_124010_create_comment_reactions_table.php
@@ -1,0 +1,51 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // Reactions are arbitrary emoji, which need utf8mb4 + a binary collation
+        // on MySQL/MariaDB (see below). Those options are engine-specific, so only
+        // apply them there and leave other drivers (pgsql, sqlite) on their native
+        // UTF-8 handling.
+        $mysqlFamily = in_array(
+            Schema::getConnection()->getDriverName(),
+            ['mysql', 'mariadb'],
+            true
+        );
+
+        Schema::create('comment_reactions', function (Blueprint $table) use ($mysqlFamily) {
+            $table->id();
+            $table->foreignId('comment_id')->constrained()->cascadeOnDelete();
+            // No DB-level FK on user_id: the user model/table is app-configurable.
+            $table->unsignedBigInteger('user_id')->index();
+
+            // A reaction is a single emoji, but one emoji can be a multi-code-point
+            // grapheme cluster (skin-tone modifiers, ZWJ sequences like 👨‍👩‍👧‍👦,
+            // flags, U+FE0F variation selectors), so 32 chars gives ample headroom.
+            $reaction = $table->string('reaction', 32);
+
+            // On MySQL/MariaDB, pin the column to utf8mb4 so 4-byte emoji store
+            // correctly (legacy utf8/utf8mb3 truncates them), and a *binary*
+            // collation so distinct emoji never collapse into the same bucket when
+            // reactions are aggregated with GROUP BY reaction.
+            if ($mysqlFamily) {
+                $reaction->charset('utf8mb4')->collation('utf8mb4_bin');
+            }
+
+            $table->timestamps();
+
+            // One reaction per user per comment.
+            $table->unique(['comment_id', 'user_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('comment_reactions');
+    }
+};

--- a/database/migrations/2025_01_06_124015_create_comment_changelogs_table.php
+++ b/database/migrations/2025_01_06_124015_create_comment_changelogs_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('comment_changelogs', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('comment_id')->constrained()->cascadeOnDelete();
+            // Snapshot of the comment body at the time of the edit.
+            $table->text('log');
+            $table->timestamp('created_at')->useCurrent();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('comment_changelogs');
+    }
+};

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         colors="true">
+    <testsuites>
+        <testsuite name="Package">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
+</phpunit>

--- a/src/Events/CommentCreated.php
+++ b/src/Events/CommentCreated.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Ssntpl\LaravelComments\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use Ssntpl\LaravelComments\Models\Comment;
+
+/**
+ * Fired after a comment is created. Apps listen to this to deliver
+ * notifications (incl. @mentions and reply alerts), broadcast, or record
+ * activity — none of which the package concerns itself with.
+ */
+class CommentCreated
+{
+    use Dispatchable, SerializesModels;
+
+    public function __construct(public Comment $comment)
+    {
+    }
+}

--- a/src/Events/CommentDeleted.php
+++ b/src/Events/CommentDeleted.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Ssntpl\LaravelComments\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use Ssntpl\LaravelComments\Models\Comment;
+
+/**
+ * Fired after a comment is deleted.
+ */
+class CommentDeleted
+{
+    use Dispatchable, SerializesModels;
+
+    public function __construct(public Comment $comment)
+    {
+    }
+}

--- a/src/Events/CommentUpdated.php
+++ b/src/Events/CommentUpdated.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Ssntpl\LaravelComments\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use Ssntpl\LaravelComments\Models\Comment;
+
+/**
+ * Fired after a comment's body is edited. `$previousBody` carries the body
+ * as it was before the edit.
+ */
+class CommentUpdated
+{
+    use Dispatchable, SerializesModels;
+
+    public function __construct(public Comment $comment, public ?string $previousBody = null)
+    {
+    }
+}

--- a/src/Events/ReactionAdded.php
+++ b/src/Events/ReactionAdded.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Ssntpl\LaravelComments\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use Ssntpl\LaravelComments\Models\CommentReaction;
+
+/**
+ * Fired when a user reacts to a comment (or changes their reaction).
+ */
+class ReactionAdded
+{
+    use Dispatchable, SerializesModels;
+
+    public function __construct(public CommentReaction $reaction)
+    {
+    }
+}

--- a/src/Events/ReactionRemoved.php
+++ b/src/Events/ReactionRemoved.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Ssntpl\LaravelComments\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use Ssntpl\LaravelComments\Models\CommentReaction;
+
+/**
+ * Fired when a user removes their reaction from a comment.
+ */
+class ReactionRemoved
+{
+    use Dispatchable, SerializesModels;
+
+    public function __construct(public CommentReaction $reaction)
+    {
+    }
+}

--- a/src/LaravelCommentsServiceProvider.php
+++ b/src/LaravelCommentsServiceProvider.php
@@ -13,7 +13,7 @@ class LaravelCommentsServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        //
+        $this->mergeConfigFrom(__DIR__ . '/../config/comments.php', 'comments');
     }
 
     /**
@@ -24,10 +24,17 @@ class LaravelCommentsServiceProvider extends ServiceProvider
     public function boot()
     {
         $this->publishes([
+            __DIR__ . '/../config/comments.php' => config_path('comments.php'),
+        ], 'laravel-comments-config');
+
+        $this->publishes([
             __DIR__ . '/../database/migrations/' => database_path('migrations'),
         ], 'laravel-comments-migrations');
 
-
-        $this->loadMigrationsFrom(__DIR__ . '/../database/migrations');
+        // Apps that own the `comments` schema themselves (e.g. otper) set
+        // `comments.auto_load_migrations` to false to avoid table collisions.
+        if (config('comments.auto_load_migrations', true)) {
+            $this->loadMigrationsFrom(__DIR__ . '/../database/migrations');
+        }
     }
 }

--- a/src/Models/Comment.php
+++ b/src/Models/Comment.php
@@ -3,41 +3,210 @@
 namespace Ssntpl\LaravelComments\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Ssntpl\LaravelComments\Events\CommentCreated;
+use Ssntpl\LaravelComments\Events\CommentDeleted;
+use Ssntpl\LaravelComments\Events\CommentUpdated;
+use Ssntpl\LaravelComments\Events\ReactionAdded;
+use Ssntpl\LaravelComments\Events\ReactionRemoved;
+use Ssntpl\LaravelComments\Support\MentionParser;
 use Ssntpl\LaravelFiles\Traits\HasFiles;
 
 class Comment extends Model
 {
     use HasFiles;
 
-    Protected $fillable = [
+    protected $fillable = [
         'type',
+        'body',
+        // Backward-compatible aliases for the renamed `body` column.
         'text',
+        'comment',
         'user_id',
-        'created_at'
+        'reply_to_comment_id',
+        'created_at',
     ];
 
-    /**
-     * The table associated with the model.
-     *
-     * @var string
-     */
     protected $table = 'comments';
 
-    public function delete()
-    {
-        $commentFiles = $this->files()->get();
-        
-        foreach($commentFiles as $commentFile)
-        {
-            $commentFile->delete();
-        }
+    /**
+     * Holds the pre-edit body between the `updating` and `updated` events so
+     * the changelog snapshot and CommentUpdated event can report it.
+     */
+    protected ?string $bodyBeforeUpdate = null;
 
-        return parent::delete();
+    protected static function booted(): void
+    {
+        static::created(function (Comment $comment) {
+            CommentCreated::dispatch($comment);
+        });
+
+        static::updating(function (Comment $comment) {
+            if ($comment->isDirty('body')) {
+                $comment->bodyBeforeUpdate = $comment->getOriginal('body');
+            }
+        });
+
+        static::updated(function (Comment $comment) {
+            if ($comment->wasChanged('body')) {
+                // Snapshot the PREVIOUS body: the changelog then holds every
+                // prior version and the model holds the current one, so the
+                // full history is reconstructable.
+                if (config('comments.changelog', false)) {
+                    $comment->changelogs()->create(['log' => $comment->bodyBeforeUpdate]);
+                }
+                CommentUpdated::dispatch($comment, $comment->bodyBeforeUpdate);
+                $comment->bodyBeforeUpdate = null;
+            }
+        });
+
+        static::deleted(function (Comment $comment) {
+            CommentDeleted::dispatch($comment);
+        });
     }
 
+    /*
+    |--------------------------------------------------------------------------
+    | Backward-compatible aliases: `text` / `comment` resolve to `body`.
+    |--------------------------------------------------------------------------
+    */
+    public function getTextAttribute()
+    {
+        return $this->body;
+    }
+
+    public function setTextAttribute($value)
+    {
+        $this->attributes['body'] = $value;
+    }
+
+    public function getCommentAttribute()
+    {
+        return $this->body;
+    }
+
+    public function setCommentAttribute($value)
+    {
+        $this->attributes['body'] = $value;
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | Relations
+    |--------------------------------------------------------------------------
+    */
     public function owner()
     {
         return $this->morphTo();
     }
 
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(config('comments.user_model', 'App\\Models\\User'), 'user_id');
+    }
+
+    public function replyToComment(): BelongsTo
+    {
+        return $this->belongsTo(config('comments.models.comment', self::class), 'reply_to_comment_id');
+    }
+
+    public function replies(): HasMany
+    {
+        return $this->hasMany(config('comments.models.comment', self::class), 'reply_to_comment_id');
+    }
+
+    public function reactions(): HasMany
+    {
+        return $this->hasMany(config('comments.models.reaction', CommentReaction::class), 'comment_id');
+    }
+
+    public function changelogs(): HasMany
+    {
+        return $this->hasMany(config('comments.models.changelog', CommentChangelog::class), 'comment_id')
+            ->orderBy('created_at', 'desc');
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | Reactions
+    |--------------------------------------------------------------------------
+    */
+
+    /**
+     * Add or change a user's reaction to this comment (one per user). Fires
+     * ReactionAdded.
+     */
+    public function react($user, string $reaction): CommentReaction
+    {
+        // Trim so stray whitespace can't create a duplicate bucket (" 👍" vs "👍").
+        // We deliberately do NOT Unicode-normalise: NFC is a no-op for emoji and
+        // won't merge presentation variants (U+FE0F is preserved by design), while
+        // skin-tone/ZWJ variants are genuinely distinct and should stay distinct.
+        $reaction = trim($reaction);
+
+        if ($reaction === '') {
+            throw new \InvalidArgumentException('A reaction must be a non-empty string; use unreact() to remove one.');
+        }
+
+        $userId = is_object($user) ? $user->getKey() : $user;
+
+        $model = $this->reactions()->updateOrCreate(
+            ['user_id' => $userId],
+            ['reaction' => $reaction],
+        );
+
+        // Don't fire on a no-op re-submit of the same reaction.
+        if ($model->wasRecentlyCreated || $model->wasChanged('reaction')) {
+            ReactionAdded::dispatch($model);
+        }
+
+        return $model;
+    }
+
+    /**
+     * Remove a user's reaction from this comment. Fires ReactionRemoved.
+     */
+    public function unreact($user): void
+    {
+        $userId = is_object($user) ? $user->getKey() : $user;
+
+        $model = $this->reactions()->where('user_id', $userId)->first();
+
+        if ($model) {
+            $model->delete();
+            ReactionRemoved::dispatch($model);
+        }
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | Mentions
+    |--------------------------------------------------------------------------
+    */
+
+    /**
+     * The @handles mentioned in this comment's body. Resolving handles to
+     * users and delivering notifications is the app's responsibility.
+     *
+     * @return string[]
+     */
+    public function mentionedHandles(): array
+    {
+        return MentionParser::handles($this->body);
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | Lifecycle
+    |--------------------------------------------------------------------------
+    */
+    public function delete()
+    {
+        foreach ($this->files()->get() as $commentFile) {
+            $commentFile->delete();
+        }
+
+        return parent::delete();
+    }
 }

--- a/src/Models/CommentChangelog.php
+++ b/src/Models/CommentChangelog.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Ssntpl\LaravelComments\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class CommentChangelog extends Model
+{
+    protected $table = 'comment_changelogs';
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'comment_id',
+        'log',
+        'created_at',
+    ];
+
+    protected $casts = [
+        'created_at' => 'datetime',
+    ];
+
+    public function comment(): BelongsTo
+    {
+        return $this->belongsTo(config('comments.models.comment', Comment::class), 'comment_id');
+    }
+}

--- a/src/Models/CommentReaction.php
+++ b/src/Models/CommentReaction.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Ssntpl\LaravelComments\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class CommentReaction extends Model
+{
+    protected $table = 'comment_reactions';
+
+    protected $fillable = [
+        'comment_id',
+        'user_id',
+        'reaction',
+    ];
+
+    public function comment(): BelongsTo
+    {
+        return $this->belongsTo(config('comments.models.comment', Comment::class), 'comment_id');
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(config('comments.user_model', 'App\\Models\\User'), 'user_id');
+    }
+}

--- a/src/Support/MentionParser.php
+++ b/src/Support/MentionParser.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Ssntpl\LaravelComments\Support;
+
+/**
+ * Extracts @mention handles from comment text. The package deliberately does
+ * NOT resolve handles to users or deliver notifications — that is app-specific
+ * and belongs in a listener on the CommentCreated / CommentUpdated events.
+ */
+class MentionParser
+{
+    /**
+     * Return the unique handles mentioned in the given text.
+     *
+     * @return string[]
+     */
+    public static function handles(?string $text): array
+    {
+        if ($text === null || $text === '') {
+            return [];
+        }
+
+        $pattern = config('comments.mentions.pattern', '/@([A-Za-z0-9_.\-]+)/');
+
+        if (! preg_match_all($pattern, $text, $matches)) {
+            return [];
+        }
+
+        return array_values(array_unique($matches[1] ?? []));
+    }
+}

--- a/src/Traits/HasComments.php
+++ b/src/Traits/HasComments.php
@@ -11,22 +11,45 @@ trait HasComments
 {
     public function comments()
     {
-        return $this->morphMany(Comment::class, 'owner');
+        return $this->morphMany(config('comments.models.comment', Comment::class), 'owner');
+    }
+
+    /**
+     * Top-level comments only (excludes threaded replies).
+     */
+    public function rootComments()
+    {
+        return $this->comments()->whereNull('reply_to_comment_id');
     }
 
     public function createComment(array $attributes = [])
     {
+        // Backward compatibility: accept `text`/`comment` as aliases for `body`.
+        foreach (['text', 'comment'] as $alias) {
+            if (empty($attributes['body']) && !empty($attributes[$alias])) {
+                $attributes['body'] = $attributes[$alias];
+            }
+        }
+
         $commentAttributes = [];
 
-        foreach (['created_at', 'user_id', 'text', 'type', 'id'] as $field) {
+        foreach (['created_at', 'user_id', 'body', 'type', 'reply_to_comment_id', 'id'] as $field) {
             if (!empty($attributes[$field])) {
                 $commentAttributes[$field] = $attributes[$field];
             }
         }
 
-        $searchCriteria = !empty($attributes['id']) ? ['id' => $attributes['id']] : $commentAttributes;
-        if($commentAttributes) {
-            return $this->comments()->updateOrCreate($searchCriteria, $commentAttributes);
+        if (! $commentAttributes) {
+            return null;
         }
+
+        // With an id, update that specific comment; without one, always create
+        // a new comment (never collapse two genuinely distinct comments that
+        // happen to share body/user/type).
+        if (! empty($attributes['id'])) {
+            return $this->comments()->updateOrCreate(['id' => $attributes['id']], $commentAttributes);
+        }
+
+        return $this->comments()->create($commentAttributes);
     }
 }

--- a/tests/Feature/CommentsTest.php
+++ b/tests/Feature/CommentsTest.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace Ssntpl\LaravelComments\Tests\Feature;
+
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Event;
+use InvalidArgumentException;
+use Ssntpl\LaravelComments\Events\CommentCreated;
+use Ssntpl\LaravelComments\Events\CommentDeleted;
+use Ssntpl\LaravelComments\Events\CommentUpdated;
+use Ssntpl\LaravelComments\Events\ReactionAdded;
+use Ssntpl\LaravelComments\Events\ReactionRemoved;
+use Ssntpl\LaravelComments\Tests\Models\TestArticle;
+use Ssntpl\LaravelComments\Tests\Models\TestUser;
+use Ssntpl\LaravelComments\Tests\TestCase;
+
+class CommentsTest extends TestCase
+{
+    private TestUser $alice;
+    private TestUser $bob;
+    private TestArticle $article;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->alice = TestUser::create(['name' => 'alice']);
+        $this->bob = TestUser::create(['name' => 'bob']);
+        $this->article = TestArticle::create(['title' => 'Post']);
+    }
+
+    public function test_creates_comment_and_body_aliases_resolve(): void
+    {
+        $c = $this->article->createComment(['user_id' => $this->alice->id, 'comment' => 'Hello']);
+
+        $this->assertSame('Hello', $c->body);
+        $this->assertSame('Hello', $c->text);     // alias
+        $this->assertSame('Hello', $c->comment);   // alias
+        $this->assertDatabaseHas('comments', ['id' => $c->id, 'body' => 'Hello']);
+    }
+
+    /** Fix 3: two identical no-id comments must not collapse into one row. */
+    public function test_duplicate_no_id_comments_create_distinct_rows(): void
+    {
+        $this->article->createComment(['user_id' => $this->alice->id, 'body' => 'ok']);
+        $this->article->createComment(['user_id' => $this->alice->id, 'body' => 'ok']);
+
+        $this->assertSame(2, $this->article->comments()->count());
+    }
+
+    public function test_create_comment_with_id_updates_in_place(): void
+    {
+        $c = $this->article->createComment(['user_id' => $this->alice->id, 'body' => 'v1']);
+        $this->article->createComment(['id' => $c->id, 'body' => 'v2']);
+
+        $this->assertSame(1, $this->article->comments()->count());
+        $this->assertSame('v2', $c->fresh()->body);
+    }
+
+    public function test_threading_and_root_comments(): void
+    {
+        $parent = $this->article->createComment(['user_id' => $this->alice->id, 'body' => 'parent']);
+        $reply = $this->article->createComment([
+            'user_id' => $this->bob->id, 'body' => 'reply', 'reply_to_comment_id' => $parent->id,
+        ]);
+
+        $this->assertSame($parent->id, $reply->replyToComment->id);
+        $this->assertSame(1, $parent->replies()->count());
+        $this->assertSame(1, $this->article->rootComments()->count());
+        $this->assertSame(2, $this->article->comments()->count());
+    }
+
+    public function test_reaction_is_unique_per_user(): void
+    {
+        $c = $this->article->createComment(['user_id' => $this->alice->id, 'body' => 'x']);
+        $c->react($this->bob, 'up');
+        $c->react($this->bob, 'heart');
+
+        $this->assertSame(1, $c->reactions()->count());
+        $this->assertSame('heart', $c->reactions()->first()->reaction);
+    }
+
+    /** Fix 5: no event on a no-op re-submit; event on an actual change. */
+    public function test_reaction_added_event_gating(): void
+    {
+        Event::fake([ReactionAdded::class]);
+        $c = $this->article->createComment(['user_id' => $this->alice->id, 'body' => 'x']);
+
+        $c->react($this->bob, 'up');
+        $c->react($this->bob, 'up');   // no-op
+        Event::assertDispatchedTimes(ReactionAdded::class, 1);
+
+        $c->react($this->bob, 'heart'); // change
+        Event::assertDispatchedTimes(ReactionAdded::class, 2);
+    }
+
+    /** Fix 6: an empty reaction is rejected. */
+    public function test_empty_reaction_is_rejected(): void
+    {
+        $c = $this->article->createComment(['user_id' => $this->alice->id, 'body' => 'x']);
+
+        $this->expectException(InvalidArgumentException::class);
+        $c->react($this->bob, '  ');
+    }
+
+    public function test_unreact_removes_and_fires_event(): void
+    {
+        Event::fake([ReactionRemoved::class]);
+        $c = $this->article->createComment(['user_id' => $this->alice->id, 'body' => 'x']);
+        $c->react($this->bob, 'up');
+
+        $c->unreact($this->bob);
+
+        $this->assertSame(0, $c->reactions()->count());
+        Event::assertDispatched(ReactionRemoved::class);
+    }
+
+    public function test_changelog_is_off_by_default(): void
+    {
+        $c = $this->article->createComment(['user_id' => $this->alice->id, 'body' => 'v1']);
+        $c->body = 'v2';
+        $c->save();
+
+        $this->assertSame(0, $c->changelogs()->count());
+    }
+
+    /** Fix 4: changelog snapshots the PRIOR body, so history is reconstructable. */
+    public function test_changelog_records_prior_body_when_enabled(): void
+    {
+        Config::set('comments.changelog', true);
+        $c = $this->article->createComment(['user_id' => $this->alice->id, 'body' => 'v1']);
+
+        $c->body = 'v2';
+        $c->save();
+        $c->body = 'v3';
+        $c->save();
+
+        $this->assertSame(['v1', 'v2'], $c->changelogs()->orderBy('id')->pluck('log')->all());
+        $this->assertSame('v3', $c->fresh()->body);
+    }
+
+    public function test_mentions_are_parsed_from_body(): void
+    {
+        $c = $this->article->createComment([
+            'user_id' => $this->alice->id, 'body' => 'ping @bob and @carol.dev again @bob',
+        ]);
+
+        // Handles are de-duplicated; dotted/hyphenated handles are supported.
+        $this->assertSame(['bob', 'carol.dev'], $c->mentionedHandles());
+    }
+
+    public function test_lifecycle_events_fire(): void
+    {
+        Event::fake([CommentCreated::class, CommentUpdated::class, CommentDeleted::class]);
+
+        $c = $this->article->createComment(['user_id' => $this->alice->id, 'body' => 'v1']);
+        Event::assertDispatched(CommentCreated::class);
+
+        $c->body = 'v2';
+        $c->save();
+        Event::assertDispatched(CommentUpdated::class, fn ($e) => $e->previousBody === 'v1');
+
+        $c->delete();
+        Event::assertDispatched(CommentDeleted::class);
+    }
+}

--- a/tests/Models/TestArticle.php
+++ b/tests/Models/TestArticle.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Ssntpl\LaravelComments\Tests\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Ssntpl\LaravelComments\Traits\HasComments;
+
+class TestArticle extends Model
+{
+    use HasComments;
+
+    protected $table = 'articles';
+
+    public $timestamps = false;
+
+    protected $fillable = ['title'];
+}

--- a/tests/Models/TestUser.php
+++ b/tests/Models/TestUser.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Ssntpl\LaravelComments\Tests\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class TestUser extends Model
+{
+    protected $table = 'users';
+
+    public $timestamps = false;
+
+    protected $fillable = ['name'];
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Ssntpl\LaravelComments\Tests;
+
+use Orchestra\Testbench\TestCase as Orchestra;
+use Ssntpl\LaravelComments\LaravelCommentsServiceProvider;
+use Ssntpl\LaravelComments\Tests\Models\TestUser;
+use Ssntpl\LaravelFiles\LaravelFilesServiceProvider;
+
+abstract class TestCase extends Orchestra
+{
+    protected function getPackageProviders($app): array
+    {
+        return [
+            LaravelFilesServiceProvider::class,
+            LaravelCommentsServiceProvider::class,
+        ];
+    }
+
+    protected function defineEnvironment($app): void
+    {
+        $app['config']->set('database.default', 'testing');
+        $app['config']->set('database.connections.testing', [
+            'driver'   => 'sqlite',
+            'database' => ':memory:',
+            'prefix'   => '',
+        ]);
+
+        $app['config']->set('comments.user_model', TestUser::class);
+        // Off by default; individual tests enable it explicitly.
+        $app['config']->set('comments.changelog', false);
+    }
+
+    protected function defineDatabaseMigrations(): void
+    {
+        $this->loadMigrationsFrom(__DIR__ . '/migrations');
+        // laravel-files `files` table, used by per-comment attachments.
+        $this->loadMigrationsFrom(__DIR__ . '/../vendor/ssntpl/laravel-files/database/migrations');
+        $this->loadMigrationsFrom(__DIR__ . '/../database/migrations');
+    }
+}

--- a/tests/migrations/2000_01_01_000000_create_test_tables.php
+++ b/tests/migrations/2000_01_01_000000_create_test_tables.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+// Minimal host + user tables for the package test suite.
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('users', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+        });
+
+        Schema::create('articles', function (Blueprint $table) {
+            $table->id();
+            $table->string('title')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('articles');
+        Schema::dropIfExists('users');
+    }
+};


### PR DESCRIPTION
## Summary
Feature release (v0.1.0) that expands the package from basic comments into a fuller commenting toolkit, while staying backward-compatible and framework-agnostic.

### Changes
- **Column rename**: `text` → `body`, with `text`/`comment` model aliases (read + write) so existing code keeps working.
- **Threading**: `reply_to_comment_id` + `replyToComment()` / `replies()` relations and `HasComments::rootComments()`.
- **Reactions**: per-user emoji reactions via `react()` / `unreact()`; `comment_reactions` table with `unique(comment_id, user_id)`; reaction column pinned to `utf8mb4` + `utf8mb4_bin` on MySQL/MariaDB and trimmed on write.
- **Edit history (opt-in)**: `comment_changelogs` snapshots on body edit, gated by `config('comments.changelog')`.
- **Lifecycle events**: `CommentCreated`, `CommentUpdated` (carries `previousBody`), `CommentDeleted`, `ReactionAdded`, `ReactionRemoved`.
- **Mentions**: `mentionedHandles()` parses `@handles` (config-driven pattern); delivery left to the app.
- **Config**: publishable `config/comments.php` (overridable models, `user_model`, `changelog`, `mentions.pattern`, `auto_load_migrations`).
- **Tooling**: bump `php` to `^8.1`; add Testbench-based test suite.

### Tests
`vendor/bin/phpunit` — 12 tests, 25 assertions, all green.

### Notes
- The `text` → `body` rename is a breaking DB change for existing installs (code paths are aliased); hence the 0.x **minor** bump.
- Apps that own the `comments` schema (e.g. otper) set `auto_load_migrations => false`.